### PR TITLE
np.int dropped in v1.24

### DIFF
--- a/e3_diffusion_for_molecules/qm9/data/prepare/qm9.py
+++ b/e3_diffusion_for_molecules/qm9/data/prepare/qm9.py
@@ -213,7 +213,7 @@ def get_unique_charges(charges):
     Get count of each charge for each molecule.
     """
     # Create a dictionary of charges
-    charge_counts = {z: np.zeros(len(charges), dtype=np.int)
+    charge_counts = {z: np.zeros(len(charges), dtype=int)
                      for z in np.unique(charges)}
     print(charge_counts.keys())
 


### PR DESCRIPTION
With the latest (as of 1/30/23) version of numpy, running main_qm9.py to train an unconditional model as described in the README throws an error because np.int was removed as of v1.24 (previously, it was an alias for the built-in python int). I'm not sure whether any other changes are necessary to bring the package up to date with v1.24, but I didn't find any other instances of np.int or np.float in the repo, and I'm able to train a model now after this fix.